### PR TITLE
feat: accept if skip minor, patch too

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -14,8 +14,8 @@
       "customType": "regex",
       "fileMatch": ["^import_map.json$", "^deno.jsonc?$"],
       "matchStrings": [
-        "['\"].+?['\"]\\s*:\\s*['\"]https://esm.sh/(?<depName>.+?)@v?(?<currentValue>\\d+?\\.\\d+?\\.\\d+?).*?['\"]",
-        "['\"].+?['\"]\\s*:\\s*['\"]npm:(?<depName>.+?)@(?<currentValue>\\d+?\\.\\d+?\\.\\d+?).*?['\"]"
+        "['\"].+?['\"]\\s*:\\s*['\"]https://esm.sh/(?<depName>.+?)@v?(?<currentValue>\\d+?(?:\\.\\d+?){0,2}).*?['\"]",
+        "['\"].+?['\"]\\s*:\\s*['\"]npm:(?<depName>.+?)@(?<currentValue>\\d+?(?:\\.\\d+?){0,2}).*?['\"]"
       ],
       "datasourceTemplate": "npm"
     },
@@ -31,8 +31,8 @@
       "customType": "regex",
       "fileMatch": ["\\.[jt]sx?$"],
       "matchStrings": [
-        "(?:im|ex)port(?:.|\\s)+?from\\s*['\"]https://esm.sh/(?<depName>.+?)@v?(?<currentValue>\\d+?\\.\\d+?\\.\\d+?).*?['\"]",
-        "(?:im|ex)port(?:.|\\s)+?from\\s*['\"]npm:(?<depName>.+?)@(?<currentValue>\\d+?\\.\\d+?\\.\\d+?).*?['\"]"
+        "(?:im|ex)port(?:.|\\s)+?from\\s*['\"]https://esm.sh/(?<depName>.+?)@v?(?<currentValue>\\d+?(?:\\.\\d+?){0,2}).*?['\"]",
+        "(?:im|ex)port(?:.|\\s)+?from\\s*['\"]npm:(?<depName>.+?)@(?<currentValue>\\d+?(?:\\.\\d+?){0,2}).*?['\"]"
       ],
       "datasourceTemplate": "npm"
     }


### PR DESCRIPTION
This PR provides feature to accept below specifier too:

- js file

```js
import { some } from "npm:some_module@1" // redirect 1.x.x latest version
export { some2 } from "https://esm.sh/some_module2@1.1" // redirect 1.1.x latest version
```

- import_map

```jsonc
{
  "import_map": {
    "some": "npm:some_module@1", // redirect 1.x.x latest version
    "some2": "https://esm.sh/some_module2@1.1" // redirect 1.1.x latest version
  }
}
```
