### PR TITLE
fix: specify x|std

### DIFF
--- a/deno/deno-land.json
+++ b/deno/deno-land.json
@@ -5,7 +5,7 @@
       "customType": "regex",
       "fileMatch": ["^import_map.json$", "^deno.jsonc?$"],
       "matchStrings": [
-        "['\"].+?['\"]\\s*:\\s*['\"](?<depName>https://deno.land/.+?)@v?(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/'\"]"
+        "['\"].+?['\"]\\s*:\\s*['\"](?<depName>https://deno.land/(?:x/.+?|std))@(?<currentValue>v?(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/'\"]"
       ],
       "datasourceTemplate": "deno"
     },
@@ -13,7 +13,7 @@
       "customType": "regex",
       "fileMatch": ["\\.[jt]sx?$"],
       "matchStrings": [
-        "(?:im|ex)port(?:.|\\s)+?from\\s*['\"](?<depName>https://deno.land/.+?)@v?(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/'\"]"
+        "(?:im|ex)port(?:.|\\s)+?from\\s*['\"](?<depName>https://deno.land/(?:x?.+?|std))@(?<currentValue>v?(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/'\"]"
       ],
       "datasourceTemplate": "deno"
     }

--- a/test/deno/deno-land.test.ts
+++ b/test/deno/deno-land.test.ts
@@ -43,7 +43,7 @@ describe("deno.land for import map", () => {
           "path": "https://deno.land/std@v0.204.0/path/mod.ts",
         }
       }`,
-      currentValue: "0.204.0",
+      currentValue: "v0.204.0",
       depName: "https://deno.land/std",
     },
     {
@@ -53,7 +53,7 @@ describe("deno.land for import map", () => {
           "some": "https://deno.land/x/some_module@v0.1.0",
         }
       }`,
-      currentValue: "0.1.0",
+      currentValue: "v0.1.0",
       depName: "https://deno.land/x/some_module",
     },
   ] as const;
@@ -89,7 +89,7 @@ describe("deno.land for import map", () => {
     {
       title: "should accept if 'v' in version",
       input: `import { someFuncion } from "https://deno.land/std@v1.0.0/some/mod.ts";`,
-      currentValue: "1.0.0",
+      currentValue: "v1.0.0",
       depName: "https://deno.land/std",
     },
     {


### PR DESCRIPTION
I think the probrem caused by ambigous regex.

So specify x|std.

fix #22
