### PR TITLE
refactor: use `it.each` instead of `for` loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "2.3.0",
   "private": true,
   "description": "renovate configuration for me",
-  "keywords": [
-    "renovate"
-  ],
+  "keywords": ["renovate"],
   "license": "zlib",
   "author": "Omochice",
   "scripts": {

--- a/test/deno/deno-land.test.ts
+++ b/test/deno/deno-land.test.ts
@@ -58,18 +58,16 @@ describe("deno.land for import map", () => {
     },
   ] as const;
 
-  for (const testCase of testCases) {
-    it(testCase.title, () => {
-      const re = regexps[0].map((r) => new RegExp(r, "gm"));
-      const matches = re
-        .map((r) => Array.from(testCase.input.matchAll(r)).map((e) => e.groups))
-        .filter((match) => match.length !== 0)
-        .flat();
-      expect(matches.length).toBe(1);
-      expect(matches[0]?.currentValue).toBe(testCase.currentValue);
-      expect(matches[0]?.depName).toBe(testCase.depName);
-    });
-  }
+  it.each(testCases)("$title", ({ input, currentValue, depName }) => {
+    const re = regexps[0].map((r) => new RegExp(r, "gm"));
+    const matches = re
+      .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
+      .filter((match) => match.length !== 0)
+      .flat();
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.currentValue).toBe(currentValue);
+    expect(matches[0]?.depName).toBe(depName);
+  });
 });
 
 describe("deno.land for import map", () => {
@@ -118,16 +116,14 @@ describe("deno.land for import map", () => {
     },
   ] as const;
 
-  for (const testCase of testCases) {
-    it(testCase.title, () => {
-      const re = regexps[1].map((r) => new RegExp(r, "gm"));
-      const matches = re
-        .map((r) => Array.from(testCase.input.matchAll(r)).map((e) => e.groups))
-        .filter((match) => match.length !== 0)
-        .flat();
-      expect(matches.length).toBe(1);
-      expect(matches[0]?.currentValue).toBe(testCase.currentValue);
-      expect(matches[0]?.depName).toBe(testCase.depName);
-    });
-  }
+  it.each(testCases)("$title", ({ input, currentValue, depName }) => {
+    const re = regexps[1].map((r) => new RegExp(r, "gm"));
+    const matches = re
+      .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
+      .filter((match) => match.length !== 0)
+      .flat();
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.currentValue).toBe(currentValue);
+    expect(matches[0]?.depName).toBe(depName);
+  });
 });

--- a/test/deno/github-tag.test.ts
+++ b/test/deno/github-tag.test.ts
@@ -78,18 +78,16 @@ describe("github tag for import_map", () => {
     },
   ];
 
-  for (const testCase of testCases) {
-    it(testCase.title, () => {
-      const re = regexps[0].map((r) => new RegExp(r, "gm"));
-      const matches = re
-        .map((r) => Array.from(testCase.input.matchAll(r)).map((e) => e.groups))
-        .filter((match) => match.length !== 0)
-        .flat();
-      expect(matches.length).toBe(1);
-      expect(matches[0]?.currentValue).toBe(testCase.currentValue);
-      expect(matches[0]?.depName).toBe(testCase.depName);
-    });
-  }
+  it.each(testCases)("$title", ({ input, currentValue, depName }) => {
+    const re = regexps[0].map((r) => new RegExp(r, "gm"));
+    const matches = re
+      .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
+      .filter((match) => match.length !== 0)
+      .flat();
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.currentValue).toBe(currentValue);
+    expect(matches[0]?.depName).toBe(depName);
+  });
 });
 
 describe("github tag for js file", () => {
@@ -157,16 +155,14 @@ describe("github tag for js file", () => {
     },
   ];
 
-  for (const testCase of testCases) {
-    it(testCase.title, () => {
-      const re = regexps[1].map((r) => new RegExp(r, "gm"));
-      const matches = re
-        .map((r) => Array.from(testCase.input.matchAll(r)).map((e) => e.groups))
-        .filter((match) => match.length !== 0)
-        .flat();
-      expect(matches.length).toBe(1);
-      expect(matches[0]?.currentValue).toBe(testCase.currentValue);
-      expect(matches[0]?.depName).toBe(testCase.depName);
-    });
-  }
+  it.each(testCases)("$title", ({ input, currentValue, depName }) => {
+    const re = regexps[1].map((r) => new RegExp(r, "gm"));
+    const matches = re
+      .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
+      .filter((match) => match.length !== 0)
+      .flat();
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.currentValue).toBe(currentValue);
+    expect(matches[0]?.depName).toBe(depName);
+  });
 });

--- a/test/deno/jsr.test.ts
+++ b/test/deno/jsr.test.ts
@@ -36,18 +36,16 @@ describe("jsr for import map", () => {
     },
   ] as const;
 
-  for (const testCase of testCases) {
-    it(testCase.title, () => {
-      const re = regexps[0].map((r) => new RegExp(r, "gm"));
-      const matches = re
-        .map((r) => Array.from(testCase.input.matchAll(r)).map((e) => e.groups))
-        .filter((match) => match.length !== 0)
-        .flat();
-      expect(matches.length).toBe(1);
-      expect(matches[0]?.currentValue).toBe(testCase.currentValue);
-      expect(matches[0]?.depName).toBe(testCase.depName);
-    });
-  }
+  it.each(testCases)("$title", ({ input, currentValue, depName }) => {
+    const re = regexps[0].map((r) => new RegExp(r, "gm"));
+    const matches = re
+      .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
+      .filter((match) => match.length !== 0)
+      .flat();
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.currentValue).toBe(currentValue);
+    expect(matches[0]?.depName).toBe(depName);
+  });
 });
 
 describe("jsr for js file", () => {
@@ -108,16 +106,14 @@ describe("jsr for js file", () => {
     },
   ] as const;
 
-  for (const testCase of testCases) {
-    it(testCase.title, () => {
-      const re = regexps[1].map((r) => new RegExp(r, "gm"));
-      const matches = re
-        .map((r) => Array.from(testCase.input.matchAll(r)).map((e) => e.groups))
-        .filter((match) => match.length !== 0)
-        .flat();
-      expect(matches.length).toBe(1);
-      expect(matches[0]?.currentValue).toBe(testCase.currentValue);
-      expect(matches[0]?.depName).toBe(testCase.depName);
-    });
-  }
+  it.each(testCases)("$title", ({ input, currentValue, depName }) => {
+    const re = regexps[1].map((r) => new RegExp(r, "gm"));
+    const matches = re
+      .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
+      .filter((match) => match.length !== 0)
+      .flat();
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.currentValue).toBe(currentValue);
+    expect(matches[0]?.depName).toBe(depName);
+  });
 });

--- a/test/deno/nest-land.test.ts
+++ b/test/deno/nest-land.test.ts
@@ -48,18 +48,16 @@ describe("x.nest.land for import_map", () => {
     },
   ];
 
-  for (const testCase of testCases) {
-    it(testCase.title, () => {
-      const re = regexps[0].map((r) => new RegExp(r, "gm"));
-      const matches = re
-        .map((r) => Array.from(testCase.input.matchAll(r)).map((e) => e.groups))
-        .filter((match) => match.length !== 0)
-        .flat();
-      expect(matches.length).toBe(1);
-      expect(matches[0]?.currentValue).toBe(testCase.currentValue);
-      expect(matches[0]?.depName).toBe(testCase.depName);
-    });
-  }
+  it.each(testCases)("$title", ({ input, currentValue, depName }) => {
+    const re = regexps[0].map((r) => new RegExp(r, "gm"));
+    const matches = re
+      .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
+      .filter((match) => match.length !== 0)
+      .flat();
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.currentValue).toBe(currentValue);
+    expect(matches[0]?.depName).toBe(depName);
+  });
 });
 
 describe("x.nest.land for js file", () => {
@@ -90,16 +88,14 @@ describe("x.nest.land for js file", () => {
     },
   ];
 
-  for (const testCase of testCases) {
-    it(testCase.title, () => {
-      const re = regexps[1].map((r) => new RegExp(r, "gm"));
-      const matches = re
-        .map((r) => Array.from(testCase.input.matchAll(r)).map((e) => e.groups))
-        .filter((match) => match.length !== 0)
-        .flat();
-      expect(matches.length).toBe(1);
-      expect(matches[0]?.currentValue).toBe(testCase.currentValue);
-      expect(matches[0]?.depName).toBe(testCase.depName);
-    });
-  }
+  it.each(testCases)("$title", ({ input, currentValue, depName }) => {
+    const re = regexps[1].map((r) => new RegExp(r, "gm"));
+    const matches = re
+      .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
+      .filter((match) => match.length !== 0)
+      .flat();
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.currentValue).toBe(currentValue);
+    expect(matches[0]?.depName).toBe(depName);
+  });
 });

--- a/test/deno/npm.test.ts
+++ b/test/deno/npm.test.ts
@@ -106,18 +106,16 @@ describe("npm for import map", () => {
     },
   ] as const;
 
-  for (const testCase of testCases) {
-    it(testCase.title, () => {
-      const re = regexps[0].map((r) => new RegExp(r, "gm"));
-      const matches = re
-        .map((r) => Array.from(testCase.input.matchAll(r)).map((e) => e.groups))
-        .filter((match) => match.length !== 0)
-        .flat();
-      expect(matches.length).toBe(1);
-      expect(matches[0]?.currentValue).toBe(testCase.currentValue);
-      expect(matches[0]?.depName).toBe(testCase.depName);
-    });
-  }
+  it.each(testCases)("$title", ({ input, currentValue, depName }) => {
+    const re = regexps[0].map((r) => new RegExp(r, "gm"));
+    const matches = re
+      .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
+      .filter((match) => match.length !== 0)
+      .flat();
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.currentValue).toBe(currentValue);
+    expect(matches[0]?.depName).toBe(depName);
+  });
 });
 
 // NOTE: This feature is not required in the imports field in deno.json and source files.
@@ -250,16 +248,14 @@ describe("npm for js file", () => {
     },
   ] as const;
 
-  for (const testCase of testCases) {
-    it(testCase.title, () => {
-      const re = regexps[1].map((r) => new RegExp(r, "gm"));
-      const matches = re
-        .map((r) => Array.from(testCase.input.matchAll(r)).map((e) => e.groups))
-        .filter((match) => match.length !== 0)
-        .flat();
-      expect(matches.length).toBe(1);
-      expect(matches[0]?.currentValue).toBe(testCase.currentValue);
-      expect(matches[0]?.depName).toBe(testCase.depName);
-    });
-  }
+  it.each(testCases)("$title", ({ input, currentValue, depName }) => {
+    const re = regexps[1].map((r) => new RegExp(r, "gm"));
+    const matches = re
+      .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
+      .filter((match) => match.length !== 0)
+      .flat();
+    expect(matches.length).toBe(1);
+    expect(matches[0]?.currentValue).toBe(currentValue);
+    expect(matches[0]?.depName).toBe(depName);
+  });
 });


### PR DESCRIPTION
fix #46 

- **test: use it.each instead of for-loop**
- **style: fmt**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved test case structure across multiple test files using `it.each` for enhanced readability and maintainability.
- **Style**
	- Reformatted the `keywords` array in `package.json` for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->