### PR TITLE
feat: support `https://jsr.io`

### DIFF
--- a/deno/jsr.json
+++ b/deno/jsr.json
@@ -5,7 +5,8 @@
       "customType": "regex",
       "fileMatch": ["(?:^|/)import_map.json$", "(?:^|/)deno.jsonc?$"],
       "matchStrings": [
-        "['\"].+?['\"]\\s*:\\s*['\"]jsr:(?<depName>@(?<namespace>.+?)/(?<package>.+?))@[\\^~]?(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/\"']"
+        "['\"].+?['\"]\\s*:\\s*['\"]jsr:(?<depName>@(?<namespace>.+?)/(?<package>.+?))@[\\^~]?(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/\"']",
+        "['\"].+?['\"]\\s*:\\s*['\"]https://jsr.io/(?<depName>@(?<namespace>.+?)/(?<package>.+?))/(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/\"']"
       ],
       "datasourceTemplate": "npm",
       "packageNameTemplate": "@jsr/{{namespace}}__{{package}}"
@@ -14,7 +15,8 @@
       "customType": "regex",
       "fileMatch": ["\\.[jt]sx?$"],
       "matchStrings": [
-        "((?:im|ex)port(?:.|\\s)+?from\\s*|//\\s*@deno-types=)['\"]jsr:(?<depName>@(?<namespace>.+?)/(?<package>.+?))@[\\^~]?(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/'\"]"
+        "((?:im|ex)port(?:.|\\s)+?from\\s*|//\\s*@deno-types=)['\"]jsr:(?<depName>@(?<namespace>.+?)/(?<package>.+?))@[\\^~]?(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/'\"]",
+        "((?:im|ex)port(?:.|\\s)+?from\\s*|//\\s*@deno-types=)['\"]https://jsr.io/(?<depName>@(?<namespace>.+?)/(?<package>.+?))/(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/'\"]"
       ],
       "datasourceTemplate": "npm",
       "packageNameTemplate": "@jsr/{{namespace}}__{{package}}"

--- a/test/deno/jsr.test.ts
+++ b/test/deno/jsr.test.ts
@@ -34,6 +34,16 @@ describe("jsr for import map", () => {
       currentValue: "1.0.1",
       depName: "@luca/flag",
     },
+    {
+      title: "should accept https://jsr.io",
+      input: `{
+        "imports": {
+          "@luca/flag": "https://jsr.io/@luca/flag/1.0.1/main.ts"
+        }
+      }`,
+      currentValue: "1.0.1",
+      depName: "@luca/flag",
+    },
   ] as const;
 
   it.each(testCases)("$title", ({ input, currentValue, depName }) => {
@@ -53,6 +63,12 @@ describe("jsr for js file", () => {
     {
       title: "should accept jsr specifier",
       input: `import { printProgress } from "jsr:@luca/flag@1.0.1";`,
+      currentValue: "1.0.1",
+      depName: "@luca/flag",
+    },
+    {
+      title: "should accept https://jsr.io",
+      input: `import { printProgress } from "https://jsr.io/@luca/flag/1.0.1/main.ts";`,
       currentValue: "1.0.1",
       depName: "@luca/flag",
     },


### PR DESCRIPTION
close #51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded support for `jsr:` dependencies to include `https://jsr.io/` URLs in `import_map.json` and `.jsx`/`.tsx` files.

- **Tests**
  - Added new test cases for handling imports from `https://jsr.io` URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->