### PR TITLE
fix: use `registryUrlTemplate` instead

### DIFF
--- a/deno/jsr.json
+++ b/deno/jsr.json
@@ -9,6 +9,7 @@
         "['\"].+?['\"]\\s*:\\s*['\"]https://jsr.io/(?<depName>@(?<namespace>.+?)/(?<package>.+?))/(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/\"']"
       ],
       "datasourceTemplate": "npm",
+      "registryUrlTemplate": "https://npm.jsr.io",
       "packageNameTemplate": "@jsr/{{namespace}}__{{package}}"
     },
     {
@@ -19,8 +20,8 @@
         "((?:im|ex)port(?:.|\\s)+?from\\s*|//\\s*@deno-types=)['\"]https://jsr.io/(?<depName>@(?<namespace>.+?)/(?<package>.+?))/(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/'\"]"
       ],
       "datasourceTemplate": "npm",
+      "registryUrlTemplate": "https://npm.jsr.io",
       "packageNameTemplate": "@jsr/{{namespace}}__{{package}}"
     }
-  ],
-  "npmrc": "@jsr:registry=https://npm.jsr.io"
+  ]
 }


### PR DESCRIPTION
Currently, use `npmrc` option seems work well.

But, it override original `npmrc` if repository has `.npmrc` too.

So use `registryUrlTemplate` instead `npmrc` to prevent the behabior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration setting for specifying a registry URL template for JSR dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->