### PR TITLE
refactor: use RE2 instead of original RegExp

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "3.1.1",
   "private": true,
   "description": "renovate configuration for me",
-  "keywords": [
-    "renovate"
-  ],
+  "keywords": ["renovate"],
   "license": "zlib",
   "author": "Omochice",
   "scripts": {
@@ -19,6 +17,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.2.2",
     "npm-run-all2": "^6.0.0",
+    "re2": "^1.21.3",
     "renovate": "^37.27.0",
     "sort-package-json": "^2.6.0",
     "vitest": "^1.0.0"

--- a/test/deno/deno-land.test.ts
+++ b/test/deno/deno-land.test.ts
@@ -1,6 +1,7 @@
 import { expect, expectTypeOf, describe, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import RE2 from "re2";
 
 const repositoryRoot = dirname(dirname(__dirname));
 
@@ -11,8 +12,8 @@ const config: string[][] = JSON.parse(file)?.customManagers?.map(
   (manager: { matchStrings?: string[] }) => manager.matchStrings,
 );
 
-const regexps: RegExp[][] = config.map((matchStrings: string[]) =>
-  matchStrings.map((re) => new RegExp(re)),
+const regexps: RE2[][] = config.map((matchStrings: string[]) =>
+  matchStrings.map((re) => new RE2(re)),
 );
 
 describe("check configuration existing", () => {
@@ -20,7 +21,7 @@ describe("check configuration existing", () => {
     expect(Array.isArray(config));
   });
   it("should be array of regexp", () => {
-    expectTypeOf(regexps).toEqualTypeOf<RegExp[][]>();
+    expectTypeOf(regexps).toEqualTypeOf<RE2[][]>();
   });
 });
 

--- a/test/deno/github-tag.test.ts
+++ b/test/deno/github-tag.test.ts
@@ -1,6 +1,7 @@
 import { expect, expectTypeOf, describe, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import RE2 from "re2";
 
 const repositoryRoot = dirname(dirname(__dirname));
 
@@ -11,8 +12,8 @@ const config: string[][] = JSON.parse(file)?.customManagers?.map(
   (manager: { matchStrings?: string[] }) => manager.matchStrings,
 );
 
-const regexps: RegExp[][] = config.map((matchStrings: string[]) =>
-  matchStrings.map((re) => new RegExp(re)),
+const regexps: RE2[][] = config.map((matchStrings: string[]) =>
+  matchStrings.map((re) => new RE2(re)),
 );
 
 describe("check configuration existing", () => {
@@ -20,7 +21,7 @@ describe("check configuration existing", () => {
     expect(Array.isArray(config));
   });
   it("should be array of regexp", () => {
-    expectTypeOf(regexps).toEqualTypeOf<RegExp[][]>();
+    expectTypeOf(regexps).toEqualTypeOf<RE2[][]>();
   });
 });
 

--- a/test/deno/jsr.test.ts
+++ b/test/deno/jsr.test.ts
@@ -1,6 +1,7 @@
 import { expect, expectTypeOf, describe, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import RE2 from "re2";
 
 const repositoryRoot = dirname(dirname(__dirname));
 
@@ -9,8 +10,8 @@ const config: string[][] = JSON.parse(file)?.customManagers?.map(
   (manager: { matchStrings?: string[] }) => manager.matchStrings,
 );
 
-const regexps: RegExp[][] = config.map((matchStrings: string[]) =>
-  matchStrings.map((re) => new RegExp(re)),
+const regexps: RE2[][] = config.map((matchStrings: string[]) =>
+  matchStrings.map((re) => new RE2(re)),
 );
 
 describe("check configuration existing", () => {
@@ -18,7 +19,7 @@ describe("check configuration existing", () => {
     expect(Array.isArray(config));
   });
   it("should be array of regexp", () => {
-    expectTypeOf(regexps).toEqualTypeOf<RegExp[][]>();
+    expectTypeOf(regexps).toEqualTypeOf<RE2[][]>();
   });
 });
 

--- a/test/deno/nest-land.test.ts
+++ b/test/deno/nest-land.test.ts
@@ -1,6 +1,7 @@
 import { expect, expectTypeOf, describe, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import RE2 from "re2";
 
 const repositoryRoot = dirname(dirname(__dirname));
 
@@ -11,8 +12,8 @@ const config: string[][] = JSON.parse(file)?.customManagers?.map(
   (manager: { matchStrings?: string[] }) => manager.matchStrings,
 );
 
-const regexps: RegExp[][] = config.map((matchStrings: string[]) =>
-  matchStrings.map((re) => new RegExp(re)),
+const regexps: RE2[][] = config.map((matchStrings: string[]) =>
+  matchStrings.map((re) => new RE2(re)),
 );
 
 describe("check configuration existing", () => {
@@ -20,7 +21,7 @@ describe("check configuration existing", () => {
     expect(Array.isArray(config));
   });
   it("should be array of regexp", () => {
-    expectTypeOf(regexps).toEqualTypeOf<RegExp[][]>();
+    expectTypeOf(regexps).toEqualTypeOf<RE2[][]>();
   });
 });
 

--- a/test/deno/npm.test.ts
+++ b/test/deno/npm.test.ts
@@ -1,6 +1,7 @@
 import { expect, expectTypeOf, describe, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import RE2 from "re2";
 
 const repositoryRoot = dirname(dirname(__dirname));
 
@@ -9,8 +10,8 @@ const config: string[][] = JSON.parse(file)?.customManagers?.map(
   (manager: { matchStrings?: string[] }) => manager.matchStrings,
 );
 
-const regexps: RegExp[][] = config.map((matchStrings: string[]) =>
-  matchStrings.map((re) => new RegExp(re)),
+const regexps: RE2[][] = config.map((matchStrings: string[]) =>
+  matchStrings.map((re) => new RE2(re)),
 );
 
 describe("check configuration existing", () => {
@@ -18,7 +19,7 @@ describe("check configuration existing", () => {
     expect(Array.isArray(config));
   });
   it("should be array of regexp", () => {
-    expectTypeOf(regexps).toEqualTypeOf<RegExp[][]>();
+    expectTypeOf(regexps).toEqualTypeOf<RE2[][]>();
   });
 });
 


### PR DESCRIPTION
renovate use RE2 as regexp engine.

close #91
