### PR TITLE
ci: set `timeout-minutes`

### DIFF
--- a/.github/workflows/_check-actions.yml
+++ b/.github/workflows/_check-actions.yml
@@ -6,6 +6,7 @@ permissions: {}
 
 jobs:
   check-actions:
+    timeout-minutes: 30
     name: Check GitHub Actions
     runs-on: ubuntu-latest
     permissions: {}

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -6,6 +6,7 @@ permissions: {}
 
 jobs:
   basic:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/enable-renovate-auto-merge.yml
+++ b/.github/workflows/enable-renovate-auto-merge.yml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   enable-auto-merge:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   path-filter:
+    timeout-minutes: 30
     outputs:
       actions: ${{steps.changes.outputs.actions}}
     runs-on: ubuntu-latest
@@ -34,6 +35,7 @@ jobs:
     uses: ./.github/workflows/_test.yml
     permissions: {}
   status-check:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     needs:
       - check-actions

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   path-filter:
+    timeout-minutes: 30
     outputs:
       actions: ${{steps.changes.outputs.actions}}
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   release-please:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,6 +19,7 @@ permissions: read-all
 
 jobs:
   analysis:
+    timeout-minutes: 30
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
ssia


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the timeout setting to 30 minutes for several GitHub Actions workflows to ensure longer-running jobs complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->