### PR TITLE
ci: use app token to run ci when create release draft PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         with:
+          token: ${{ steps.app-token.outputs.token }}
           release-type: node


### PR DESCRIPTION
Currently, use github bot token.

It can not run CI when create release draft PR.

So I use app token to run it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions release workflow to use a more secure authentication method with GitHub App token.
	- Improved release process authentication mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->