### PR TITLE
ci: specify `onlyBuiltDependencies`

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -25,7 +25,6 @@ jobs:
       - name: setup pnpm
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
         with:
-          version: latest
           run_install: true
       - name: run test
         run: pnpm test

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "sort-package-json": "^2.6.0",
     "vitest": "^2.0.0"
   },
-  "packageManager": "pnpm@10.3.0"
+  "packageManager": "pnpm@10.3.0",
+  "pnpm": {
+    "onlyBuiltDependencies": ["re2", "@biomejs/biome"]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "3.2.0",
   "private": true,
   "description": "Shareable configuration for Renovate within Deno project",
-  "keywords": [
-    "renovate"
-  ],
+  "keywords": ["renovate"],
   "license": "zlib",
   "author": "Omochice",
   "scripts": {
@@ -24,5 +22,6 @@
     "renovate": "^39.0.0",
     "sort-package-json": "^2.6.0",
     "vitest": "^2.0.0"
-  }
+  },
+  "packageManager": "pnpm@10.3.0"
 }


### PR DESCRIPTION
After pnpm v10, `onlyBuiltDependencies` is needed to install some dependencies.

It does not have changes for user who use this configure as renovate's `extends`.

- **chore: specify pnpm version**
- **ci: use version from package.json**
- **chore: specify `onlyBuiltDependencies`**

close #447



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined the dependency installation workflow for a smoother build process.
  - Streamlined package management settings and consolidated keyword configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->