### PR TITLE
ci: move configs to root

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,13 +1,9 @@
 {
+  "release-type": "node",
+  "changelog-path": "CHANGELOG.md",
+  "include-component-in-tag": false,
   "packages": {
-    ".": {
-      "changelog-path": "CHANGELOG.md",
-      "release-type": "node",
-      "bump-minor-pre-major": false,
-      "bump-patch-for-minor-pre-major": false,
-      "draft": false,
-      "prerelease": false
-    }
+    ".": {}
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
This fix will likely make the release's CI work properly.
