### PR TITLE
docs: fix path to badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @Omochice/renovate-config
 
-[![Checks for push](https://github.com/Omochice/renovate-config/actions/workflows/push.yml/badge.svg)](https://github.com/Omochice/renovate-config/actions/workflows/push.yml)
+[![Checks for push](https://github.com/Omochice/renovate-config/actions/workflows/check.yml/badge.svg)](https://github.com/Omochice/renovate-config/actions/workflows/check.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Omochice/renovate-config/badge)](https://scorecard.dev/viewer/?uri=github.com/Omochice/renovate-config)
 
 A configuration for Renovate.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @Omochice/renovate-config
 
-[![Checks for push](https://github.com/Omochice/renovate-config/actions/workflows/check.yml/badge.svg)](https://github.com/Omochice/renovate-config/actions/workflows/check.yml)
+[![Check Workflow](https://github.com/Omochice/renovate-config/actions/workflows/check.yml/badge.svg)](https://github.com/Omochice/renovate-config/actions/workflows/check.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Omochice/renovate-config/badge)](https://scorecard.dev/viewer/?uri=github.com/Omochice/renovate-config)
 
 A configuration for Renovate.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README badge to reference a different GitHub Actions workflow and label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->