### PR TITLE
feat!: use jsonata custom manager instead

### DIFF
--- a/deno/deno-land.json
+++ b/deno/deno-land.json
@@ -2,13 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "customManagers": [
     {
-      "customType": "regex",
+      "customType": "jsonata",
+      "fileFormat": "json",
       "managerFilePatterns": [
         "/(?:^|/)import_map.json$/",
         "/(?:^|/)deno.jsonc?$/"
       ],
       "matchStrings": [
-        "['\"].+?['\"]\\s*:\\s*['\"](?<depName>https://deno.land/(?:x/.+?|std))@(?<currentValue>v?(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/'\"]"
+        "imports.*[$ ~> /^https:\\/\\/deno.land\\/(x\\/|std)/i] ~> $map(function($v) {( $package := $v ~> /^(https:\\/\\/deno.land\\/(x\\/.+?|std))@(v?(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)(-((0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*))?)?)?)/; { 'currentValue': $package.groups[2], 'depName': $package.groups[0] })})"
       ],
       "datasourceTemplate": "deno"
     },

--- a/deno/github-tag.json
+++ b/deno/github-tag.json
@@ -2,14 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "customManagers": [
     {
-      "customType": "regex",
+      "customType": "jsonata",
+      "fileFormat": "json",
       "managerFilePatterns": [
         "/(?:^|/)import_map.json$/",
         "/(?:^|/)deno.jsonc?$/"
       ],
       "matchStrings": [
-        "['\"].+?['\"]\\s*:\\s*['\"]https://pax.deno.dev/(?<depName>.+?/.+?)@(?<currentValue>[^'\"]+?)[/'\"]",
-        "\".+?\"\\s*:\\s*['\"]https://raw.githubusercontent.com/(?<depName>.+?/.+?)/(?<currentValue>[^'\"]+?)[/'\"]"
+        "imports.*[$ ~> /^https:\\/\\/(raw\\.githubusercontent\\.com|pax\\.deno\\.dev)\\//i] ~> $map(function($v) {( $package := $v ~> $replace(/^https:\\/\\/(raw\\.githubusercontent\\.com|pax\\.deno\\.dev)\\//, '') ~> /^((.+?)\\/(.+?))[/@](.+?)($|\\/)/; { 'depName': $package.groups[0], 'currentValue': $package.groups[3] })})"
       ],
       "datasourceTemplate": "github-tags"
     },

--- a/deno/jsr.json
+++ b/deno/jsr.json
@@ -2,14 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "customManagers": [
     {
-      "customType": "regex",
+      "customType": "jsonata",
+      "fileFormat": "json",
       "managerFilePatterns": [
         "/(?:^|/)import_map.json$/",
         "/(?:^|/)deno.jsonc?$/"
       ],
       "matchStrings": [
-        "['\"].+?['\"]\\s*:\\s*['\"]jsr:(?<depName>@(?<namespace>.+?)/(?<package>.+?))@[\\^~]?(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/\"']",
-        "['\"].+?['\"]\\s*:\\s*['\"]https://jsr.io/(?<depName>@(?<namespace>.+?)/(?<package>.+?))/(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/\"']"
+        "imports.*[$ ~> /^(jsr:|https:\\/\\/jsr.io\\/)/i] ~> $map(function($v) {( $package := $v ~> $replace(/^(jsr:|https:\\/\\/jsr.io\\/)/i, '') ~> /(@(.+?)/(.+?))[@|\\/][\\^~]?((0|[1-9]\\d*)(\\.(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)(-((0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*))?)?)?)/; { 'depName': $package.groups[0], 'namespace': $package.groups[1], 'package': $package.groups[2], 'currentValue': $package.groups[3] })})"
       ],
       "datasourceTemplate": "npm",
       "registryUrlTemplate": "https://npm.jsr.io",

--- a/deno/jsr.json
+++ b/deno/jsr.json
@@ -9,11 +9,10 @@
         "/(?:^|/)deno.jsonc?$/"
       ],
       "matchStrings": [
-        "imports.*[$ ~> /^(jsr:|https:\\/\\/jsr.io\\/)/i] ~> $map(function($v) {( $package := $v ~> $replace(/^(jsr:|https:\\/\\/jsr.io\\/)/i, '') ~> /(@(.+?)/(.+?))[@|\\/][\\^~]?((0|[1-9]\\d*)(\\.(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)(-((0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*))?)?)?)/; { 'depName': $package.groups[0], 'namespace': $package.groups[1], 'package': $package.groups[2], 'currentValue': $package.groups[3] })})"
+        "imports.*[$ ~> /^(jsr:|https:\\/\\/jsr.io\\/)/i] ~> $map(function($v) {( $package := $v ~> $replace(/^(jsr:|https:\\/\\/jsr.io\\/)/i, '') ~> /(@(.+?)/(.+?))[@|\\/][\\^~]?((0|[1-9]\\d*)(\\.(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)(-((0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*))?)?)?)/; { 'depName': $package.groups[0], 'packageName': '@jsr/' & $package.groups[1] & '__' & $package.groups[2], 'currentValue': $package.groups[3] })})"
       ],
       "datasourceTemplate": "npm",
-      "registryUrlTemplate": "https://npm.jsr.io",
-      "packageNameTemplate": "@jsr/{{namespace}}__{{package}}"
+      "registryUrlTemplate": "https://npm.jsr.io"
     },
     {
       "customType": "regex",

--- a/deno/nest-land.json
+++ b/deno/nest-land.json
@@ -2,13 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "customManagers": [
     {
-      "customType": "regex",
+      "customType": "jsonata",
+      "fileFormat": "json",
       "managerFilePatterns": [
         "/(?:^|/)import_map.json$/",
         "/(?:^|/)deno.jsonc?$/"
       ],
       "matchStrings": [
-        "['\"].+?['\"]\\s*:\\s*['\"]https://x.nest.land/(?<depName>.+?)@(?<currentValue>v?(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/'\"]"
+        "imports.*[$ ~> /^https:\\/\\/x\\.nest\\.land\\//i] ~> $map(function($v) {( $package := $v ~> $replace(/^https:\\/\\/x.nest.land\\//, '') ~> /^(.+?)@(v?(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)(-((0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*))?)?)?)/; { 'depName': $package.groups[0], 'currentValue': $package.groups[1] })})"
       ],
       "datasourceTemplate": "custom.nest-land"
     },

--- a/deno/npm.json
+++ b/deno/npm.json
@@ -2,16 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "customManagers": [
     {
-      "customType": "regex",
+      "customType": "jsonata",
+      "fileFormat": "json",
       "managerFilePatterns": [
         "/(?:^|/)import_map.json$/",
         "/(?:^|/)deno.jsonc?$/"
       ],
       "matchStrings": [
-        "['\"].+?['\"]\\s*:\\s*['\"]https://esm.sh/(?<depName>.+?)@v?(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[?/\"']",
-        "['\"].+?['\"]\\s*:\\s*['\"]npm:[/]?(?<depName>.+?)@v?(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/\"']",
-        "['\"].+?['\"]\\s*:\\s*['\"]https?://unpkg.com/(?<depName>(?:@[^/\"']*/)?[^/\"']*?)@v?(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[/\"']",
-        "['\"].+?['\"]\\s*:\\s*['\"]https?://cdn.skypack.dev/(?<depName>(?:@[^/\"']*/)?[^/\"']*?)@v?(?<currentValue>(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?)?)?)[?/\"']"
+        "imports.*[$ ~> /^(npm:|https:\\/\\/(esm\\.sh|unpkg\\.com|cdn\\.skypack\\.dev)\\/)/i] ~> $map(function($v) {( $package := $v ~> $replace(/^(npm:\\/?|https:\\/\\/(esm\\.sh|unpkg\\.com|cdn\\.skypack\\.dev)\\/)/i, '') ~> /^(.+?)@v?((0|[1-9]\\d*)(\\.(0|[1-9]\\d*)(\\.(0|[1-9]\\d*)(-((0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\\+([0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*))?)?)?)/; { 'depName': $package.groups[0], 'currentValue': $package.groups[1] })})"
       ],
       "datasourceTemplate": "npm"
     },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.1.1",
     "dedent": "1.6.0",
+    "jsonata": "^2.0.6",
     "npm-run-all2": "8.0.4",
     "re2": "1.22.1",
     "renovate": "41.32.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       dedent:
         specifier: 1.6.0
         version: 1.6.0
+      jsonata:
+        specifier: ^2.0.6
+        version: 2.0.6
       npm-run-all2:
         specifier: 8.0.4
         version: 8.0.4

--- a/test/deno/deno-land.test.ts
+++ b/test/deno/deno-land.test.ts
@@ -30,8 +30,8 @@ describe("deno.land for import map", () => {
     {
       title: "should be accept deno.land/std",
       input: `{
-        "import_map": {
-          "std": "https://deno.land/std@0.204.0",
+        "imports": {
+          "std": "https://deno.land/std@0.204.0"
         }
       }`,
       currentValue: "0.204.0",
@@ -40,8 +40,8 @@ describe("deno.land for import map", () => {
     {
       title: "should be accept if include 'v' in version",
       input: `{
-        "import_map": {
-          "path": "https://deno.land/std@v0.204.0/path/mod.ts",
+        "imports": {
+          "path": "https://deno.land/std@v0.204.0/path/mod.ts"
         }
       }`,
       currentValue: "v0.204.0",
@@ -50,8 +50,8 @@ describe("deno.land for import map", () => {
     {
       title: "should be accept deno.land/x",
       input: `{
-        "import_map": {
-          "some": "https://deno.land/x/some_module@v0.1.0",
+        "imports": {
+          "some": "https://deno.land/x/some_module@v0.1.0"
         }
       }`,
       currentValue: "v0.1.0",

--- a/test/deno/deno-land.test.ts
+++ b/test/deno/deno-land.test.ts
@@ -1,20 +1,19 @@
-import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import jsonata, { type Expression } from "jsonata";
 import RE2 from "re2";
 import { describe, expect, expectTypeOf, it } from "vitest";
+import { parse } from "../util";
 
 const repositoryRoot = dirname(dirname(__dirname));
+const config = parse(join(repositoryRoot, "deno", "deno-land.json"));
 
-const file = readFileSync(
-  join(repositoryRoot, "deno", "deno-land.json"),
-).toString();
-const config: string[][] = JSON.parse(file)?.customManagers?.map(
-  (manager: { matchStrings?: string[] }) => manager.matchStrings,
-);
+const regexps: RE2[][] = config.customManagers
+  .filter(({ customType }) => customType === "regex")
+  .map(({ matchStrings }) => matchStrings.map((re) => new RE2(re)));
 
-const regexps: RE2[][] = config.map((matchStrings: string[]) =>
-  matchStrings.map((re) => new RE2(re)),
-);
+const jsonatas: Expression[][] = config.customManagers
+  .filter(({ customType }) => customType === "jsonata")
+  .map(({ matchStrings }) => matchStrings.map((re) => jsonata(re)));
 
 describe("check configuration existing", () => {
   it("should be array", () => {
@@ -59,15 +58,18 @@ describe("deno.land for import map", () => {
     },
   ] as const;
 
-  it.each(testCases)("$title", ({ input, currentValue, depName }) => {
-    const re = regexps[0].map((r) => new RegExp(r, "gm"));
-    const matches = re
-      .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
-      .filter((match) => match.length !== 0)
-      .flat();
+  it.each(testCases)("$title", async ({ input, currentValue, depName }) => {
+    const data = JSON.parse(input);
+    const matches = (
+      await Promise.all(
+        jsonatas.at(0)?.map(async (j) => await j.evaluate(data)) ?? [],
+      )
+    ).flat();
+    expect(matches).toBeDefined();
+    expect(Array.isArray(matches)).toBe(true);
     expect(matches.length).toBe(1);
-    expect(matches[0]?.currentValue).toBe(currentValue);
-    expect(matches[0]?.depName).toBe(depName);
+    expect(matches.at(0).currentValue).toBe(currentValue);
+    expect(matches.at(0).depName).toBe(depName);
   });
 });
 
@@ -124,7 +126,7 @@ describe("deno.land for import map", () => {
   ] as const;
 
   it.each(testCases)("$title", ({ input, currentValue, depName }) => {
-    const re = regexps[1].map((r) => new RegExp(r, "gm"));
+    const re = regexps[0].map((r) => new RegExp(r, "gm"));
     const matches = re
       .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
       .filter((match) => match.length !== 0)

--- a/test/deno/github-tag.test.ts
+++ b/test/deno/github-tag.test.ts
@@ -1,19 +1,19 @@
 import { dirname, join } from "node:path";
+import jsonata, { type Expression } from "jsonata";
 import RE2 from "re2";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { parse } from "../util";
 
 const repositoryRoot = dirname(dirname(__dirname));
+const config = parse(join(repositoryRoot, "deno", "github-tag.json"));
 
-const config: string[][] = parse(
-  join(repositoryRoot, "deno", "github-tag.json"),
-).customManagers.map(
-  (manager: { matchStrings: string[] }) => manager.matchStrings,
-);
+const regexps: RE2[][] = config.customManagers
+  .filter(({ customType }) => customType === "regex")
+  .map(({ matchStrings }) => matchStrings.map((re) => new RE2(re)));
 
-const regexps: RE2[][] = config.map((matchStrings: string[]) =>
-  matchStrings.map((re) => new RE2(re)),
-);
+const jsonatas: Expression[][] = config.customManagers
+  .filter(({ customType }) => customType === "jsonata")
+  .map(({ matchStrings }) => matchStrings.map((re) => jsonata(re)));
 
 describe("check configuration existing", () => {
   it("should be array", () => {
@@ -60,7 +60,7 @@ describe("github tag for import_map", () => {
       title: "should accept complex semver version",
       input: `{
         "imports": {
-          "sample": "https://raw.githubusercontent.com/user/repo/1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay/mod.ts
+          "sample": "https://raw.githubusercontent.com/user/repo/1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay/mod.ts"
         }
       }`,
       currentValue: "1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay",
@@ -78,15 +78,18 @@ describe("github tag for import_map", () => {
     },
   ];
 
-  it.each(testCases)("$title", ({ input, currentValue, depName }) => {
-    const re = regexps[0].map((r) => new RegExp(r, "gm"));
-    const matches = re
-      .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
-      .filter((match) => match.length !== 0)
-      .flat();
+  it.each(testCases)("$title", async ({ input, currentValue, depName }) => {
+    const data = JSON.parse(input);
+    const matches = (
+      await Promise.all(
+        jsonatas.at(0)?.map(async (j) => await j.evaluate(data)) ?? [],
+      )
+    ).flat();
+    expect(matches).toBeDefined();
+    expect(Array.isArray(matches)).toBe(true);
     expect(matches.length).toBe(1);
-    expect(matches[0]?.currentValue).toBe(currentValue);
-    expect(matches[0]?.depName).toBe(depName);
+    expect(matches.at(0).currentValue).toBe(currentValue);
+    expect(matches.at(0).depName).toBe(depName);
   });
 });
 
@@ -162,7 +165,7 @@ describe("github tag for js file", () => {
   ];
 
   it.each(testCases)("$title", ({ input, currentValue, depName }) => {
-    const re = regexps[1].map((r) => new RegExp(r, "gm"));
+    const re = regexps[0].map((r) => new RegExp(r, "gm"));
     const matches = re
       .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
       .filter((match) => match.length !== 0)

--- a/test/deno/github-tag.test.ts
+++ b/test/deno/github-tag.test.ts
@@ -1,15 +1,14 @@
-import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import RE2 from "re2";
 import { describe, expect, expectTypeOf, it } from "vitest";
+import { parse } from "../util";
 
 const repositoryRoot = dirname(dirname(__dirname));
 
-const file = readFileSync(
+const config: string[][] = parse(
   join(repositoryRoot, "deno", "github-tag.json"),
-).toString();
-const config: string[][] = JSON.parse(file)?.customManagers?.map(
-  (manager: { matchStrings?: string[] }) => manager.matchStrings,
+).customManagers.map(
+  (manager: { matchStrings: string[] }) => manager.matchStrings,
 );
 
 const regexps: RE2[][] = config.map((matchStrings: string[]) =>

--- a/test/deno/github-tag.test.ts
+++ b/test/deno/github-tag.test.ts
@@ -31,7 +31,7 @@ describe("github tag for import_map", () => {
       title: "should accept raw.githubusercontent.com",
       input: `{
         "imports": {
-          "sample": "https://raw.githubusercontent.com/user/repo/1.0.0/mod.ts",
+          "sample": "https://raw.githubusercontent.com/user/repo/1.0.0/mod.ts"
         }
       }`,
       currentValue: "1.0.0",
@@ -41,7 +41,7 @@ describe("github tag for import_map", () => {
       title: "should accept pax.deno.dev",
       input: `{
         "imports": {
-          "sample": "https://pax.deno.dev/user/repo@1.0.0/mod.ts",
+          "sample": "https://pax.deno.dev/user/repo@1.0.0/mod.ts"
         }
       }`,
       currentValue: "1.0.0",
@@ -51,7 +51,7 @@ describe("github tag for import_map", () => {
       title: "should accept omit 'mod.ts' when specify pax.deno.dev",
       input: `{
         "imports": {
-          "sample": "https://pax.deno.dev/user/repo@1.0.0",
+          "sample": "https://pax.deno.dev/user/repo@1.0.0"
         }
       }`,
       currentValue: "1.0.0",
@@ -61,7 +61,7 @@ describe("github tag for import_map", () => {
       title: "should accept complex semver version",
       input: `{
         "imports": {
-          "sample": "https://raw.githubusercontent.com/user/repo/1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay/mod.ts"
+          "sample": "https://raw.githubusercontent.com/user/repo/1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay/mod.ts
         }
       }`,
       currentValue: "1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay",

--- a/test/deno/jsr.test.ts
+++ b/test/deno/jsr.test.ts
@@ -1,14 +1,15 @@
-import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import dedent from "dedent";
 import RE2 from "re2";
 import { describe, expect, expectTypeOf, it } from "vitest";
+import { parse } from "../util";
 
 const repositoryRoot = dirname(dirname(__dirname));
 
-const file = readFileSync(join(repositoryRoot, "deno", "jsr.json")).toString();
-const config: string[][] = JSON.parse(file)?.customManagers?.map(
-  (manager: { matchStrings?: string[] }) => manager.matchStrings,
+const config: string[][] = parse(
+  join(repositoryRoot, "deno", "jsr.json"),
+).customManagers.map(
+  (manager: { matchStrings: string[] }) => manager.matchStrings,
 );
 
 const regexps: RE2[][] = config.map((matchStrings: string[]) =>

--- a/test/deno/jsr.test.ts
+++ b/test/deno/jsr.test.ts
@@ -1,20 +1,21 @@
 import { dirname, join } from "node:path";
 import dedent from "dedent";
+import jsonata, { type Expression } from "jsonata";
 import RE2 from "re2";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { parse } from "../util";
 
 const repositoryRoot = dirname(dirname(__dirname));
 
-const config: string[][] = parse(
-  join(repositoryRoot, "deno", "jsr.json"),
-).customManagers.map(
-  (manager: { matchStrings: string[] }) => manager.matchStrings,
-);
+const config = parse(join(repositoryRoot, "deno", "jsr.json"));
 
-const regexps: RE2[][] = config.map((matchStrings: string[]) =>
-  matchStrings.map((re) => new RE2(re)),
-);
+const regexps: RE2[][] = config.customManagers
+  .filter(({ customType }) => customType === "regex")
+  .map(({ matchStrings }) => matchStrings.map((re) => new RE2(re)));
+
+const jsonatas: Expression[][] = config.customManagers
+  .filter(({ customType }) => customType === "jsonata")
+  .map(({ matchStrings }) => matchStrings.map((re) => jsonata(re)));
 
 describe("check configuration existing", () => {
   it("should be array", () => {
@@ -49,15 +50,18 @@ describe("jsr for import map", () => {
     },
   ] as const;
 
-  it.each(testCases)("$title", ({ input, currentValue, depName }) => {
-    const re = regexps[0].map((r) => new RegExp(r, "gm"));
-    const matches = re
-      .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
-      .filter((match) => match.length !== 0)
-      .flat();
+  it.each(testCases)("$title", async ({ input, currentValue, depName }) => {
+    const data = JSON.parse(input);
+    const matches = (
+      await Promise.all(
+        jsonatas.at(0)?.map(async (j) => await j.evaluate(data)) ?? [],
+      )
+    ).flat();
+    expect(matches).toBeDefined();
+    expect(Array.isArray(matches)).toBe(true);
     expect(matches.length).toBe(1);
-    expect(matches[0]?.currentValue).toBe(currentValue);
-    expect(matches[0]?.depName).toBe(depName);
+    expect(matches.at(0).currentValue).toBe(currentValue);
+    expect(matches.at(0).depName).toBe(depName);
   });
 });
 
@@ -143,7 +147,7 @@ describe("jsr for js file", () => {
   ] as const;
 
   it.each(testCases)("$title", ({ input, currentValue, depName }) => {
-    const re = regexps[1].map((r) => new RegExp(r, "gm"));
+    const re = regexps[0].map((r) => new RegExp(r, "gm"));
     const matches = re
       .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
       .filter((match) => match.length !== 0)

--- a/test/deno/jsr.test.ts
+++ b/test/deno/jsr.test.ts
@@ -37,6 +37,7 @@ describe("jsr for import map", () => {
       }`,
       currentValue: "1.0.1",
       depName: "@luca/flag",
+      packageName: "@jsr/luca__flag",
     },
     {
       title: "should accept https://jsr.io",
@@ -47,22 +48,27 @@ describe("jsr for import map", () => {
       }`,
       currentValue: "1.0.1",
       depName: "@luca/flag",
+      packageName: "@jsr/luca__flag",
     },
   ] as const;
 
-  it.each(testCases)("$title", async ({ input, currentValue, depName }) => {
-    const data = JSON.parse(input);
-    const matches = (
-      await Promise.all(
-        jsonatas.at(0)?.map(async (j) => await j.evaluate(data)) ?? [],
-      )
-    ).flat();
-    expect(matches).toBeDefined();
-    expect(Array.isArray(matches)).toBe(true);
-    expect(matches.length).toBe(1);
-    expect(matches.at(0).currentValue).toBe(currentValue);
-    expect(matches.at(0).depName).toBe(depName);
-  });
+  it.each(testCases)(
+    "$title",
+    async ({ input, currentValue, depName, packageName }) => {
+      const data = JSON.parse(input);
+      const matches = (
+        await Promise.all(
+          jsonatas.at(0)?.map(async (j) => await j.evaluate(data)) ?? [],
+        )
+      ).flat();
+      expect(matches).toBeDefined();
+      expect(Array.isArray(matches)).toBe(true);
+      expect(matches.length).toBe(1);
+      expect(matches.at(0).currentValue).toBe(currentValue);
+      expect(matches.at(0).depName).toBe(depName);
+      expect(matches.at(0).packageName).toBe(packageName);
+    },
+  );
 });
 
 describe("jsr for js file", () => {

--- a/test/deno/nest-land.test.ts
+++ b/test/deno/nest-land.test.ts
@@ -1,19 +1,19 @@
 import { dirname, join } from "node:path";
+import jsonata, { type Expression } from "jsonata";
 import RE2 from "re2";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { parse } from "../util";
 
 const repositoryRoot = dirname(dirname(__dirname));
+const config = parse(join(repositoryRoot, "deno", "nest-land.json"));
 
-const config: string[][] = parse(
-  join(repositoryRoot, "deno", "nest-land.json"),
-).customManagers.map(
-  (manager: { matchStrings: string[] }) => manager.matchStrings,
-);
+const regexps: RE2[][] = config.customManagers
+  .filter(({ customType }) => customType === "regex")
+  .map(({ matchStrings }) => matchStrings.map((re) => new RE2(re)));
 
-const regexps: RE2[][] = config.map((matchStrings: string[]) =>
-  matchStrings.map((re) => new RE2(re)),
-);
+const jsonatas: Expression[][] = config.customManagers
+  .filter(({ customType }) => customType === "jsonata")
+  .map(({ matchStrings }) => matchStrings.map((re) => jsonata(re)));
 
 describe("check configuration existing", () => {
   it("should be array", () => {
@@ -48,15 +48,18 @@ describe("x.nest.land for import_map", () => {
     },
   ];
 
-  it.each(testCases)("$title", ({ input, currentValue, depName }) => {
-    const re = regexps[0].map((r) => new RegExp(r, "gm"));
-    const matches = re
-      .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
-      .filter((match) => match.length !== 0)
-      .flat();
+  it.each(testCases)("$title", async ({ input, currentValue, depName }) => {
+    const data = JSON.parse(input);
+    const matches = (
+      await Promise.all(
+        jsonatas.at(0)?.map(async (j) => await j.evaluate(data)) ?? [],
+      )
+    ).flat();
+    expect(matches).toBeDefined();
+    expect(Array.isArray(matches)).toBe(true);
     expect(matches.length).toBe(1);
-    expect(matches[0]?.currentValue).toBe(currentValue);
-    expect(matches[0]?.depName).toBe(depName);
+    expect(matches.at(0).currentValue).toBe(currentValue);
+    expect(matches.at(0).depName).toBe(depName);
   });
 });
 
@@ -95,7 +98,7 @@ describe("x.nest.land for js file", () => {
   ];
 
   it.each(testCases)("$title", ({ input, currentValue, depName }) => {
-    const re = regexps[1].map((r) => new RegExp(r, "gm"));
+    const re = regexps[0].map((r) => new RegExp(r, "gm"));
     const matches = re
       .map((r) => Array.from(input.matchAll(r)).map((e) => e.groups))
       .filter((match) => match.length !== 0)

--- a/test/deno/nest-land.test.ts
+++ b/test/deno/nest-land.test.ts
@@ -31,7 +31,7 @@ describe("x.nest.land for import_map", () => {
       title: "should accept x.nest.land",
       input: `{
         "imports": {
-          "sample": "https://x.nest.land/sample@0.0.1/mod.ts",
+          "sample": "https://x.nest.land/sample@0.0.1/mod.ts"
         }
       }`,
       currentValue: "0.0.1",
@@ -41,7 +41,7 @@ describe("x.nest.land for import_map", () => {
       title: "should accept x.nest.land with `v`",
       input: `{
         "imports": {
-          "sample": "https://x.nest.land/sample@v0.0.1/mod.ts",
+          "sample": "https://x.nest.land/sample@v0.0.1/mod.ts"
         }
       }`,
       currentValue: "v0.0.1",

--- a/test/deno/nest-land.test.ts
+++ b/test/deno/nest-land.test.ts
@@ -1,15 +1,14 @@
-import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import RE2 from "re2";
 import { describe, expect, expectTypeOf, it } from "vitest";
+import { parse } from "../util";
 
 const repositoryRoot = dirname(dirname(__dirname));
 
-const file = readFileSync(
+const config: string[][] = parse(
   join(repositoryRoot, "deno", "nest-land.json"),
-).toString();
-const config: string[][] = JSON.parse(file)?.customManagers?.map(
-  (manager: { matchStrings?: string[] }) => manager.matchStrings,
+).customManagers.map(
+  (manager: { matchStrings: string[] }) => manager.matchStrings,
 );
 
 const regexps: RE2[][] = config.map((matchStrings: string[]) =>

--- a/test/deno/npm.test.ts
+++ b/test/deno/npm.test.ts
@@ -29,7 +29,7 @@ describe("npm for import map", () => {
       title: "should accept npm specifier",
       input: `{
         "imports": {
-          "chalk": "npm:chalk@5.0.1",
+          "chalk": "npm:chalk@5.0.1"
         }
       }`,
       currentValue: "5.0.1",
@@ -39,7 +39,7 @@ describe("npm for import map", () => {
       title: "should accept esm.sh specifier",
       input: `{
         "imports": {
-          "chalk": "https://esm.sh/chalk@5.0.1",
+          "chalk": "https://esm.sh/chalk@5.0.1"
         }
       }`,
       currentValue: "5.0.1",
@@ -49,7 +49,7 @@ describe("npm for import map", () => {
       title: "should accept esm.sh specifier with query",
       input: `{
         "imports": {
-          "tslib": "https://esm.sh/tslib@2.6.2?exports=__await,__rest",
+          "tslib": "https://esm.sh/tslib@2.6.2?exports=__await,__rest"
         }
       }`,
       currentValue: "2.6.2",
@@ -59,7 +59,7 @@ describe("npm for import map", () => {
       title: "should accept only major version",
       input: `{
         "imports": {
-          "chalk": "npm:chalk@5",
+          "chalk": "npm:chalk@5"
         }
       }`,
       currentValue: "5",
@@ -69,7 +69,7 @@ describe("npm for import map", () => {
       title: "should accept unpkg.com specifier",
       input: `{
         "imports": {
-          "foo": "https://unpkg.com/@bar/foo@0.1.0/foo.ts",
+          "foo": "https://unpkg.com/@bar/foo@0.1.0/foo.ts"
         }
       }`,
       currentValue: "0.1.0",
@@ -79,7 +79,7 @@ describe("npm for import map", () => {
       title: "should accept unpkg.com specifier without @scope",
       input: `{
         "imports": {
-          "foo": "https://unpkg.com/foo@0.1.0/umd/foo.production.min.js",
+          "foo": "https://unpkg.com/foo@0.1.0/umd/foo.production.min.js"
         }
       }`,
       currentValue: "0.1.0",
@@ -89,7 +89,7 @@ describe("npm for import map", () => {
       title: "should accept skypack.dev specifier",
       input: `{
         "imports": {
-          "foo": "https://cdn.skypack.dev/@scope/package@10.5.5",
+          "foo": "https://cdn.skypack.dev/@scope/package@10.5.5"
         }
       }`,
       currentValue: "10.5.5",
@@ -99,7 +99,7 @@ describe("npm for import map", () => {
       title: "should accept skypack.dev with query",
       input: `{
         "imports": {
-          "foo": "https://cdn.skypack.dev/@scope/package@10.5.5?min",
+          "foo": "https://cdn.skypack.dev/@scope/package@10.5.5?min"
         }
       }`,
       currentValue: "10.5.5",

--- a/test/deno/npm.test.ts
+++ b/test/deno/npm.test.ts
@@ -1,13 +1,14 @@
-import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import RE2 from "re2";
 import { describe, expect, expectTypeOf, it } from "vitest";
+import { parse } from "../util";
 
 const repositoryRoot = dirname(dirname(__dirname));
 
-const file = readFileSync(join(repositoryRoot, "deno", "npm.json")).toString();
-const config: string[][] = JSON.parse(file)?.customManagers?.map(
-  (manager: { matchStrings?: string[] }) => manager.matchStrings,
+const config: string[][] = parse(
+  join(repositoryRoot, "deno", "npm.json"),
+).customManagers.map(
+  (manager: { matchStrings: string[] }) => manager.matchStrings,
 );
 
 const regexps: RE2[][] = config.map((matchStrings: string[]) =>

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+
+type CustomManager = {
+  customType: "jsonata" | "regex";
+  matchStrings: string[];
+};
+
+export type Config = {
+  customManagers: CustomManager[];
+};
+
+export const parse = (path: string): Config => {
+  return JSON.parse(readFileSync(path).toString());
+};


### PR DESCRIPTION
close #467

- **chore: add jsonata**
- **test: fix import map schema**
- **chore: migrate biome v2**
- **test: add test utils**
- **style: apply biome v2**
- **test: use parse util instead**
- **feat!: use jsonata manager instead**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Renovate custom manager configurations to use JSONata expressions for improved dependency extraction from import maps.
  * Added the `jsonata` package as a development dependency.

* **Tests**
  * Refactored test suites to support JSONata-based matching for import map dependencies.
  * Introduced a utility for parsing configuration files in tests.

* **New Features**
  * Enhanced dependency detection in import maps with more robust and flexible matching logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->