### PR TITLE
ci: prevent to fail ci when use setup/node v5

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -18,13 +18,12 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
+      - name: setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - name: Install Node.js ${{ matrix.node }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
-      - name: setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          run_install: true
+      - run: pnpm install
       - name: run test
         run: pnpm test

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -24,5 +24,6 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
+          cache: pnpm
       - run: pnpm install
       - run: pnpm run test

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -25,5 +25,4 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: pnpm install
-      - name: run test
-        run: pnpm test
+      - run: pnpm run test


### PR DESCRIPTION
related: #1181

- **ci: reorder setups**
- **ci: omit redundant name**
- **ci: specify cache**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI pipelines with dedicated package manager setup and caching to speed up builds and ensure consistent dependency installs.
  * Split installation and test execution into separate steps for clearer logs and easier troubleshooting.
  * No changes to product behavior or public APIs.

* **Tests**
  * Improved reliability of test runs in CI by refining execution steps.
  * No changes to test coverage or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->