### PR TITLE
chore: use devEngines instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,13 @@
     "vitest": "4.1.4"
   },
   "packageManager": "pnpm@10.33.0",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "10.33.0",
+      "onFail": "download"
+    }
+  },
   "pnpm": {
     "onlyBuiltDependencies": [
       "re2",


### PR DESCRIPTION
some tool needs `packageManager` field. So we remain it.
