### PR TITLE
ci: check only lts

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -8,10 +8,6 @@ jobs:
   basic:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ["24.15.0", "lts/*", "current"]
     permissions: {}
     steps:
       - name: Checkout
@@ -20,10 +16,10 @@ jobs:
           persist-credentials: false
       - name: setup pnpm
         uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
-      - name: Install Node.js ${{ matrix.node }}
+      - name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ${{ matrix.node }}
+          node-version: "24.15.0"
           cache: pnpm
       - run: pnpm install
       - run: pnpm run test

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,18 +5,4 @@
     "github>aquaproj/aqua-renovate-config#2.12.0",
     "customManagers:biomeVersions",
   ],
-  customManagers: [
-    {
-      customType: "jsonata",
-      fileFormat: "yaml",
-      managerFilePatterns: [
-        "/.github/workflows/_test.yml$/",
-      ],
-      matchStrings: [
-        "{ 'currentValue': jobs.basic.strategy.matrix.node[0] }",
-      ],
-      datasourceTemplate: "node-version",
-      depNameTemplate: "node",
-    },
-  ],
 }


### PR DESCRIPTION
## Summary

Check regexp only on lts.

## Details

Sometime, RE2 is broken on `current` version. (cause by node-gyp.)

Renovate doesn't support the `current` version, we follow it.

Since this is a change only to the CI, it does not affect the config provided to users.

## Confirmation

CI work well. (on this PR)

## Limitation

None.
